### PR TITLE
Fix dropping one well per run in barcode-filter.tsv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ pipeline/%/lt-X.tsv: pipeline/%/plates.txt pipeline/%/guided
 # finally clean up the pipeline/run/plate/well.map.bam into columns
 pipeline/%/barcode-filter.tsv: pipeline/%/freebayes-tidy.tsv
 	@echo "Checking for contaminated barcodes"
-	@awk 'NR > 1{print "pipeline",$$1,$$2,$$3".map.bam "$$4" "$$6" "$$7}' \
+	@awk '{print "pipeline",$$1,$$2,$$3".map.bam "$$4" "$$6" "$$7}' \
 	    OFS='/' $< \
 	    | python src/bc-contam.py - \
 	    | mlr --tsvlite --implicit-csv-header \


### PR DESCRIPTION
I noticed a bug when trying to create [testcases](https://github.com/octantbio/octopus/blob/add-testcases/test/pOK_barcode-aggregated-stats.tsv) that drops exactly one well before running `src/bc-contam.py`. This makes the well's BC_Contam status as "NA" even if it has a barcode (in which case it should strictly be TRUE or FALSE). For this particular run, well A03 is affected:

```
Run     Plate   Well    BC_Contam       bc1
pOK_barcode_test        Plate01 A01-A01-CGTACGTA        NA      NA
pOK_barcode_test        Plate01 A02-A02-AGCTAGCT        NA      NA
pOK_barcode_test        Plate01 A03-A03-GCTTAACG        NA      GTCCGGTACTCAAAAGTATTTGGT      <-----
pOK_barcode_test        Plate01 A04-A04-ATCCGGTA        FALSE   GTCGCTTCTAAAACTGAAGCTATG
pOK_barcode_test        Plate01 A05-A05-TAGGCCAT        FALSE   TTCATTTAGTTGTAATACTTCCTT
```

I determined that the `Makefile` is skipping the first line of `freebayes-tidy.tsv` as if it were a header, but that's not the case here. Looking at one run of the `pOK_barcode_test` data, you'll note that A03 is the first line:

```
     1  pOK_barcode_test        Plate01 A03-A03-GCTTAACG        input_pOK_barcoded      1       GTCCGGTACTCAAAAGTATTTGGT        1117    1       1       1
     2  pOK_barcode_test        Plate01 A01-A01-CGTACGTA        input_pOK_barcoded      1       NA      NA      21      0       1
     3  pOK_barcode_test        Plate01 A04-A04-ATCCGGTA        input_pOK_barcoded      1       GTCGCTTCTAAAACTGAAGCTATG        1117    1       1       1
     4  pOK_barcode_test        Plate01 A02-A02-AGCTAGCT        input_pOK_barcoded      1       NA      NA      10      0       1
     5  pOK_barcode_test        Plate01 A05-A05-TAGGCCAT        input_pOK_barcoded      1       TTCATTTAGTTGTAATACTTCCTT        1117    1       1       1
```

This behavior is inconsistent from run to run since freebayes-tidy.tsv isn't guaranteed to be sorted.

The solution here is straightforward as I just removed the bit of AWK responsible for skipping the first line.