### PR TITLE
Added computational pipeline to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# backups and bytecode
+*.swp
+*/__pycache__
+
+# git stuff
+.git
+
+# input and output files
+data
+pipeline

--- a/Dockerfile
+++ b/Dockerfile
@@ -200,4 +200,11 @@ RUN install2.r --error \
     optparse
 
 #===============================================================================
+# set up this version of the pipeline inside the image under /opt
+RUN mkdir -p /opt/octopus/data /opt/octopus/pipeline
+# copy latest source code, test data, and Makefile
+COPY src/ /opt/octopus/src/
+COPY test/ /opt/octopus/test
+COPY LICENSE Makefile /opt/octopus/
+
 WORKDIR /home


### PR DESCRIPTION
Quick change that installs the latest version of the computational pipeline to the Docker image during the build process. I'm proposing this change so that we can easily run our testcases inside of the image for CI. 

More broadly, this is a step towards an executable image, so end-users don't have to worry about cloning this repository and keeping it up-to-date.