### PR TITLE
add n_vars check to test_pipeline.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ RUN set -u; \
 # python requirements 
 WORKDIR /usr/local
 RUN set -u; \
-    curl https://bootstrap.pypa.io/get-pip.py | python3 \
+    curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | python3 \
     && pip install \
     pandas \
     numpy \

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -35,6 +35,7 @@ def compare_aggregated_stats(expected_fn: str, actual_fn: str):
                                 suffixes=("_expected", "_actual"))
 
     assert all_equal_or_NA(test_df, "DeNovo_Ref_expected", "DeNovo_Ref_actual")
+    assert all_equal_or_NA(test_df, "n_vars_expected", "n_vars_actual")
     assert all_equal_or_NA(test_df, "bc1_expected", "bc1_actual")
     assert all_equal_or_NA(test_df, "BC_Contam_expected", "BC_Contam_actual")
 


### PR DESCRIPTION
Due to a minor oversight when we first wrote the testcases, we aren't currently testing the "n_vars" column of the aggregated-stats.tsv. This is just a quick fix that adds that test. 