### PR TITLE
Set up CD via GitHub actions

### DIFF
--- a/.github/workflows/dockerhub-deploy.yml
+++ b/.github/workflows/dockerhub-deploy.yml
@@ -1,0 +1,46 @@
+# Update the image of octopus available on DockerHub.
+
+name: DockerHub Deployment
+
+# Only run this action when we've merged changes to the codebase into master.
+on:
+  push:
+     branches:
+       - 'master'
+     paths: ["Makefile", "src/**", "test/**", ".github/workflows/dockerhub-deploy.yml"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+  
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    
+    # We're not doing any kind of semantic versioning on our image tags,
+    # but we want to keep a backup in case the latest image gets borked.
+    # So we use the current date as an additional tag.
+    - name: Getting the current date
+      run:  echo "current_date=$(date +%Y.%m.%d-%H.%M.%S)" >> $GITHUB_ENV
+    
+    # TODO: use some sort of build cache to speed this up.
+    # Takes around ~20 minutes to compile tidyverse packages.
+    - name: Build image and push to DockerHub
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        # overwrite the previous 'latest' image and create a duplicate with today's date 
+        # tags: octantbio/octopus:latest, octantbio/octopus:${{ env.current_date }}
+        tags: octantbio/octopus:${{ env.current_date }}
+


### PR DESCRIPTION
I created a GitHub action that will build the image and [push to DockerHub](https://hub.docker.com/repository/docker/octant/octopus/) whenever we merge a relevant change into master. 

Somewhat notable here: whenever you push an image with an already existing tag (e.g. "latest") the previous image is overwritten on DockerHub. So, this action with also push a duplicate tag with the current date / time as a backup. If the latest image ever gets borked for a period of time, you can pull an earlier image by the date.

Eventually setting up semantic versioning would be nice here, but that would require making GitHub releases, tagging commits, and a more hands-on workflow for maintainers. Instead, I want this to be a automatic as possible to ensure the image always stays up-to-date.